### PR TITLE
Admin bookings: include patient name instead of patient_id

### DIFF
--- a/app/Http/Controllers/Admin/AdminBookingController.php
+++ b/app/Http/Controllers/Admin/AdminBookingController.php
@@ -14,7 +14,7 @@ class AdminBookingController extends Controller
      */
     public function index()
     {
-        $bookings = Booking::orderBy('time_slot_start', 'desc')->get();
+        $bookings = Booking::with('patients')->get();
 
         return AdminBookingResource::collection($bookings);
     }
@@ -25,7 +25,8 @@ class AdminBookingController extends Controller
      */
     public function byPatient(int $patientId)
     {
-        $bookings = Booking::where('patient_id', $patientId)
+        $bookings = Booking::with('patients')
+            ->where('patient_id', $patientId)
             ->orderBy('time_slot_start', 'desc')
             ->get();
 

--- a/app/Http/Resources/Admin/AdminBookingResource.php
+++ b/app/Http/Resources/Admin/AdminBookingResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources\Admin;
 
+use App\Http\Resources\PatientResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class AdminBookingResource extends JsonResource
@@ -13,15 +14,7 @@ class AdminBookingResource extends JsonResource
     return [
         'booking_id'      => $this->booking_id,
 
-        'patient' => $patient ? [
-            'patient_id' => $patient->patient_id,
-            'first_name' => $patient->first_name,
-            'last_name'  => $patient->last_name,
-            'name'       => trim(($patient->first_name ?? '').' '.($patient->last_name ?? '')),
-            'age'        => $patient->age,
-            'sex'        => $patient->sex,
-            'location'   => $patient->location,
-        ] : null,
+        'patient' => PatientResource::make($this->patients),
 
         'time_slot_start' => $this->time_slot_start,
         'time_slot_end'   => $this->time_slot_end,


### PR DESCRIPTION
Previously AdminBookingResource returned only patient_id. For admin/doctor use this is not helpful, so the resource now returns the related patient info (name + basic data) to make bookings readable. 

Changes:

- Updated app/Http/Resources/AdminBookingResource.php

- Replace patient_id with nested patient object (id, first_name, last_name, name, age, sex, location)

- Keep existing booking fields: booking_id, time_slot_start, time_slot_end, status